### PR TITLE
Zoom and Drag with zoomOffset

### DIFF
--- a/include/Layer.js
+++ b/include/Layer.js
@@ -7,10 +7,10 @@ class Layer {
     constructor(canvas) {
         this.canvas = canvas;
         this.context = canvas.getContext('2d');
-        this.shapes = Array();
-        this.offset = {x: 0, y: 0};
+        this.shapes = Array();        
         this.zoomFactor = 1;
         this.zoomOffset = {x: 0, y: 0};
+        this.offset = {x: 0, y: 0};
     }
 
     /**
@@ -35,7 +35,10 @@ class Layer {
         props.zoom = 1;
         props = this.sketch(shape, props);
         
-        props.offset = this.offset;
+        props.offset = {
+            x: this.offset.x + this.zoomOffset.x,
+            y: this.offset.y + this.zoomOffset.y
+        };
         props.zoom = this.zoomFactor;
         props = shape.validateProps(props);
         this.shapes.push({shape: shape.clone(), props: props});
@@ -43,7 +46,7 @@ class Layer {
     
     setZoomFactor(props) {
         this.zoomFactor = props.zoom;
-        this.zoomOffset = props.offset;
+        this.zoomOffset = props.zoomOffset;
 
         this.clear(true);
         this.context.save();
@@ -51,8 +54,8 @@ class Layer {
         let matrix = this.context.getTransform();
         matrix.a = Math.sign(matrix.a) * props.zoom;
         matrix.d = Math.sign(matrix.a) * props.zoom;
-        matrix.e = this.offset.x + props.offset.x;
-        matrix.f = this.offset.y + props.offset.y;
+        matrix.e = this.offset.x + props.zoomOffset.x;
+        matrix.f = this.offset.y + props.zoomOffset.y;
         
         this.context.setTransform(matrix);
         

--- a/include/Layer.js
+++ b/include/Layer.js
@@ -10,6 +10,7 @@ class Layer {
         this.shapes = Array();
         this.offset = {x: 0, y: 0};
         this.zoomFactor = 1;
+        this.zoomOffset = {x: 0, y: 0};
     }
 
     /**
@@ -42,7 +43,7 @@ class Layer {
     
     setZoomFactor(props) {
         this.zoomFactor = props.zoom;
-        this.offset = props.offset;
+        this.zoomOffset = props.offset;
 
         this.clear(true);
         this.context.save();
@@ -50,8 +51,8 @@ class Layer {
         let matrix = this.context.getTransform();
         matrix.a = Math.sign(matrix.a) * props.zoom;
         matrix.d = Math.sign(matrix.a) * props.zoom;
-        matrix.e = props.offset.x;
-        matrix.f = props.offset.y;
+        matrix.e = this.offset.x + props.offset.x;
+        matrix.f = this.offset.y + props.offset.y;
         
         this.context.setTransform(matrix);
         
@@ -77,8 +78,8 @@ class Layer {
         let matrix = this.context.getTransform();
         matrix.a = Math.sign(matrix.a) * this.zoomFactor;
         matrix.d = Math.sign(matrix.a) * this.zoomFactor;
-        matrix.e = this.offset.x;
-        matrix.f = this.offset.y;
+        matrix.e = this.offset.x + this.zoomOffset.x;
+        matrix.f = this.offset.y + this.zoomOffset.y;
         
         this.context.setTransform(matrix);
         

--- a/include/Stage.js
+++ b/include/Stage.js
@@ -154,8 +154,8 @@ class Stage {
      */
     center() {
         this.drag(
-            -1 * this.offset.x + (this.trace.canvas.width / 2 + this.zoomOffset.x) / 2, 
-            -1 * this.offset.y + (this.trace.canvas.height / 2 + this.zoomOffset.y) / 2
+            -1 * (this.offset.x + this.zoomOffset.x) + this.trace.canvas.width * ( 1- this.zoomFactor) / 2, 
+            -1 * (this.offset.y + this.zoomOffset.y) + this.trace.canvas.height * ( 1- this.zoomFactor) / 2
         );
     }
 

--- a/include/Stage.js
+++ b/include/Stage.js
@@ -21,6 +21,7 @@ class Stage {
         // initial offset value
         this.offset = {x: 0, y: 0};
         this.zoomFactor = 1;
+        this.zoomOffset = {x: 0, y: 0}
         this.zoomStep = 0.2;
 
         // Default layers:
@@ -98,15 +99,15 @@ class Stage {
     zoomIn(event) {
         this.zoomFactor += this.zoomStep;
         let props = {
-            x: (event.mousOver) ? event.x - this.offset.x : this.trace.canvas.width / 2 - this.offset.x,
-            y: (event.mousOver) ? event.y - this.offset.y : this.trace.canvas.height / 2 - this.offset.y,
+            x: (event.mousOver) ? event.x - this.offset.x: this.trace.canvas.width / 2,
+            y: (event.mousOver) ? event.y - this.offset.y: this.trace.canvas.height / 2,
             zoom: this.zoomFactor.toFixed(1)
         };
 
-        props.offset = { 
-            x: props.x * (1 - this.zoomFactor),
-            y: props.y * (1 - this.zoomFactor) 
-        };
+        this.zoomOffset.x -= (props.x - this.zoomOffset.x) / (this.zoomFactor - this.zoomStep) * this.zoomStep;
+        this.zoomOffset.y -= (props.y - this.zoomOffset.y ) / (this.zoomFactor - this.zoomStep) * this.zoomStep;
+
+        props.zoomOffset = this.zoomOffset;
         
         this.main.setZoomFactor(props);
         return this.zoomFactor.toFixed(1);
@@ -116,15 +117,15 @@ class Stage {
         if (this.zoomFactor > (2 * this.zoomStep)) {
             this.zoomFactor -= this.zoomStep;
             let props = {
-                x: (event.mousOver) ? event.x - this.offset.x : this.trace.canvas.width / 2 - this.offset.x,
-                y: (event.mousOver) ? event.y - this.offset.y : this.trace.canvas.height / 2 - this.offset.y,
+                x: (event.mousOver) ? event.x - this.offset.x: this.trace.canvas.width / 2,
+                y: (event.mousOver) ? event.y - this.offset.y: this.trace.canvas.height / 2,
                 zoom: this.zoomFactor.toFixed(1)
             };
     
-            props.offset = { 
-                x: props.x * (1 - this.zoomFactor),
-                y: props.y * (1 - this.zoomFactor) 
-            };
+            this.zoomOffset.x += (props.x - this.zoomOffset.x) / (this.zoomFactor + this.zoomStep) * this.zoomStep;
+            this.zoomOffset.y += (props.y - this.zoomOffset.y ) / (this.zoomFactor + this.zoomStep) * this.zoomStep;
+
+            props.zoomOffset = this.zoomOffset;
 
             this.main.setZoomFactor(props);
         }
@@ -141,6 +142,7 @@ class Stage {
         this.offset.y += y;
 
         this.main.drag(this.offset.x, this.offset.y);
+
         $("input[name='ox']").val(this.offset.x);
         $("input[name='oy']").val(this.offset.y);
         
@@ -152,8 +154,9 @@ class Stage {
      */
     center() {
         this.drag(
-            -1 * this.offset.x + (1 - this.zoomFactor) * this.trace.canvas.width / 2, 
-            -1 * this.offset.y + (1 - this.zoomFactor) * this.trace.canvas.height / 2
+            -1 * this.offset.x + (this.trace.canvas.width / 2 + this.zoomOffset.x) / 2, 
+            -1 * this.offset.y + (this.trace.canvas.height / 2 + this.zoomOffset.y) / 2
         );
     }
+
 }

--- a/include/Stage.js
+++ b/include/Stage.js
@@ -98,29 +98,17 @@ class Stage {
     zoomIn(event) {
         this.zoomFactor += this.zoomStep;
         let props = {
-            x: (event.mousOver) ? event.x : this.trace.canvas.width / 2,
-            y: (event.mousOver) ? event.y : this.trace.canvas.height / 2,
+            x: (event.mousOver) ? event.x - this.offset.x : this.trace.canvas.width / 2 - this.offset.x,
+            y: (event.mousOver) ? event.y - this.offset.y : this.trace.canvas.height / 2 - this.offset.y,
             zoom: this.zoomFactor.toFixed(1)
         };
 
-        /**
-         * use this way, 
-         * to make it Zoom In always relatively the center of the canvas:
-         *  this.offset.x -= this.zoomStep * this.trace.canvas.width / 2;
-         *  this.offset.y -= this.zoomStep * this.trace.canvas.height / 2;
-         * 
-         * use this way,
-         * to make Zoom In relatively the mouse position:
-         *  this.offset.x -= this.zoomStep * props.x;
-         *  this.offset.y -= this.zoomStep * props.y;
-         */
-        this.offset.x -= (event.mousOver) ? this.zoomStep * props.x : this.zoomStep * this.trace.canvas.width / 2;
-        this.offset.y -= (event.mousOver) ? this.zoomStep * props.y : this.zoomStep * this.trace.canvas.height / 2;
-        props.offset = this.offset;
-
+        props.offset = { 
+            x: props.x * (1 - this.zoomFactor),
+            y: props.y * (1 - this.zoomFactor) 
+        };
+        
         this.main.setZoomFactor(props);
-        $("input[name='ox']").val(this.offset.x);
-        $("input[name='oy']").val(this.offset.y);
         return this.zoomFactor.toFixed(1);
     }
 
@@ -128,30 +116,17 @@ class Stage {
         if (this.zoomFactor > (2 * this.zoomStep)) {
             this.zoomFactor -= this.zoomStep;
             let props = {
-                x: (event.mousOver) ? event.x : this.trace.canvas.width / 2,
-                y: (event.mousOver) ? event.y : this.trace.canvas.height / 2,
+                x: (event.mousOver) ? event.x - this.offset.x : this.trace.canvas.width / 2 - this.offset.x,
+                y: (event.mousOver) ? event.y - this.offset.y : this.trace.canvas.height / 2 - this.offset.y,
                 zoom: this.zoomFactor.toFixed(1)
             };
     
-            /**
-             * use this way, 
-             * to make it Zoom Out relatively the center ot the canvas:
-             *  this.offset.x += this.zoomStep * this.trace.canvas.width / 2;
-             *  this.offset.y += this.zoomStep * this.trace.canvas.height / 2;
-             * 
-             * use this way, 
-             * to make Zoom Out relatively the mouse position:
-             *  this.offset.x += this.zoomStep * props.x;
-             *  this.offset.y += this.zoomStep * props.y;
-             */
-            this.offset.x += (event.mousOver) ? this.zoomStep * props.x : this.zoomStep * this.trace.canvas.width / 2;
-            this.offset.y += (event.mousOver) ? this.zoomStep * props.y : this.zoomStep * this.trace.canvas.height / 2;
-
-            props.offset = this.offset;
+            props.offset = { 
+                x: props.x * (1 - this.zoomFactor),
+                y: props.y * (1 - this.zoomFactor) 
+            };
 
             this.main.setZoomFactor(props);
-            $("input[name='ox']").val(this.offset.x);
-            $("input[name='oy']").val(this.offset.y);
         }
         return this.zoomFactor.toFixed(1);
     }


### PR DESCRIPTION
rework-ed Zoom In/Out functionality again as described in #1 (ZoomIn/ZoomOut), comment id [642753256](https://github.com/filkovsp/WEB-Drawing-App/issues/1#issuecomment-642753256) to make it work similar way as [AutoCAD](https://web.autocad.com) app does. Zoom should change scale of the Context and also apply addition offset to the drawing so that the same point at the drawing under the mouse pointer before zoom would move to the same point under the mouse pointer after zoom happened. To make it work, additional offset parameter has been required - zoomOffset that watches the scale-specific offset for the drawing.
Stage class is responsible for calculating and applying regular offset and zoom offset params.
